### PR TITLE
Replace absolute paths with relative in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(an_driver)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-#add_compile_options(-std=c++11)
+add_compile_options(-std=c++11)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,5 +200,5 @@ include_directories(
 #########################
 ## Advanced Navigation ##
 #########################
-add_executable(an_driver ~/ros/src/an_driver/src/an_driver.cpp ~/ros/src/an_driver/src/spatial_packets.c ~/ros/src/an_driver/src/an_packet_protocol.c ~/ros/src/an_driver/src/rs232/rs232.c)
+add_executable(an_driver src/an_driver.cpp src/spatial_packets.c src/an_packet_protocol.c src/rs232/rs232.c)
 target_link_libraries(an_driver ${catkin_LIBRARIES})


### PR DESCRIPTION
Full paths to source files were hardcoded CMakeLists.txt which results in build errors on most systems. Replace absolute paths with relative.

Also add C++11 flag to add support for extended initializer lists.